### PR TITLE
Update README.md with correct use of Browserify

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ var gulp = require('gulp')
 gulp.task('build', function() {
   var bundler = browserify('./index.js')
 
-  return bundler.pipe()
+  return bundler.bundle()
     .pipe(source('index.js'))
     .pipe(buffer())
     .pipe(uglify())


### PR DESCRIPTION
Apparently there was a tiny mistake in the example: the method `pipe()` was called on the Browserify bundler instead of  `bundle()`. [Related SO question](http://stackoverflow.com/q/43792598/1233251)